### PR TITLE
fix: get include dir from the steps installed headers

### DIFF
--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -90,6 +90,25 @@ pub fn extractIncludeDirsFromCompileStep(b: *std.Build, step: *std.Build.Compile
         }
     }
 
+    for (step.installed_headers.items) |header| {
+        const pathstr = extractIncludeDirFromInstallFileStep(header.cast(std.Build.Step.InstallFile).?) catch |err| {
+            switch (err) {
+                GraphSerializeError.InvalidHeader => continue,
+            }
+        };
+
+        // make sure the installed header's directory isn't already in the list
+        var should_add = true;
+        for (dirs.items) |item| {
+            if (std.mem.eql(u8, item, pathstr)) {
+                should_add = false;
+                break;
+            }
+        }
+
+        if (should_add) dirs.append(pathstr) catch @panic("OOM");
+    }
+
     return dirs.toOwnedSlice() catch @panic("OOM");
 }
 


### PR DESCRIPTION
previously, any include dirs added by target.installHeader() didn't appear to get added to the compile commands.json. I found this when working with raylib's build.zig (the original lib, no bindings). This fixes that.