### PR TITLE
Accurate source paths and slightly more accurate object paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 zig-cache/
+.zig-cache/
 zig-out/
 .direnv/

--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -5,6 +5,12 @@ var compile_steps: ?[]*std.Build.Step.Compile = null;
 
 const CSourceFiles = std.Build.Module.CSourceFiles;
 
+/// A list of files (by absolute path) to compile with the given flags
+const AbsoluteCSourceFiles = struct {
+    files: []const []const u8,
+    flags: []const []const u8,
+};
+
 const CompileCommandEntry = struct {
     arguments: []const []const u8,
     directory: []const u8,
@@ -89,11 +95,32 @@ pub fn extractIncludeDirsFromCompileStep(b: *std.Build, step: *std.Build.Step.Co
     return dirs_as_strings.toOwnedSlice() catch @panic("OOM");
 }
 
+/// If a file is given to zig by absolute path, this function does nothing.
+/// Otherwise, it makes the relative path to the source file absolute by
+/// appending it to the builder passed in to this function.
+fn makeCSourcePathsAbsolute(b: *std.Build, c_sources: CSourceFiles) AbsoluteCSourceFiles {
+    var cpaths = std.ArrayList([]const u8).init(b.allocator);
+    defer cpaths.deinit();
+
+    for (c_sources.files) |file| {
+        if (std.fs.path.isAbsolute(file)) {
+            cpaths.append(file) catch @panic("OOM");
+        } else {
+            cpaths.append(c_sources.root.getPath(b, file));
+        }
+    }
+
+    return AbsoluteCSourceFiles{
+        .files = cpaths.toOwnedSlice() catch @panic("OOM"),
+        .flags = c_sources.flags,
+    };
+}
+
 // NOTE: some of the CSourceFiles pointed at by the elements of the returned
 // array are allocated with the allocator, some are not.
-fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*CSourceFiles {
+fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*AbsoluteCSourceFiles {
     var allocator = b.allocator;
-    var res = std.ArrayList(*CSourceFiles).init(allocator);
+    var res = std.ArrayList(*AbsoluteCSourceFiles).init(allocator);
 
     // move the compile steps into a mutable dynamic array, so we can add
     // any child steps
@@ -147,27 +174,27 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*CSource
                     continue;
                 },
                 .c_source_file => {
-                    // convert C source file into c source fileS
+                    // convert C source file into absolute C source files
                     const path = link_object.c_source_file.file.getPath(b);
                     var files_mem = allocator.alloc([]const u8, 1) catch @panic("Allocation failure, probably OOM");
                     files_mem[0] = path;
 
-                    const source_file = allocator.create(CSourceFiles) catch @panic("Allocation failure, probably OOM");
+                    const abs_source_file = allocator.create(AbsoluteCSourceFiles) catch @panic("Allocation failure, probably OOM");
 
                     var flags = std.ArrayList([]const u8).init(allocator);
                     flags.appendSlice(link_object.c_source_file.flags) catch @panic("OOM");
                     flags.appendSlice(shared_flags.items) catch @panic("OOM");
 
-                    source_file.* = CSourceFiles{
+                    abs_source_file.* = makeCSourcePathsAbsolute(step.owner, CSourceFiles{
                         .root = .{ .src_path = .{
                             .owner = b,
                             .sub_path = "",
                         } },
                         .files = files_mem,
                         .flags = flags.toOwnedSlice() catch @panic("OOM"),
-                    };
+                    });
 
-                    res.append(source_file) catch @panic("OOM");
+                    res.append(abs_source_file) catch @panic("OOM");
                 },
                 .c_source_files => {
                     var source_files = link_object.c_source_files;
@@ -176,7 +203,7 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*CSource
                     flags.appendSlice(shared_flags.items) catch @panic("OOM");
                     source_files.flags = flags.toOwnedSlice() catch @panic("OOM");
 
-                    res.append(source_files) catch @panic("OOM");
+                    res.append(makeCSourcePathsAbsolute(step.owner, source_files)) catch @panic("OOM");
                 },
             }
         }
@@ -207,18 +234,15 @@ fn makeCdb(step: *std.Build.Step, prog_node: std.Progress.Node) anyerror!void {
     const c_sources = getCSources(step.owner, compile_steps.?);
 
     // fill compile command entries, one for each file
-    for (c_sources) |c_source_file_set| {
-        const flags = c_source_file_set.flags;
-        for (c_source_file_set.files) |c_file| {
-            const file_str = if (std.fs.path.isAbsolute(c_file)) c_file else step.owner.path(c_file);
-
-            const output_str = b.fmt("{s}.o", .{file_str});
+    for (c_sources) |absolute_c_source_files| {
+        const flags = absolute_c_source_files.flags;
+        for (absolute_c_source_files.files) |c_file| {
+            // NOTE: this is not accurate- not actually generating the hashed subdirectory names
+            const output_str = b.fmt("{s}.o", .{b.pathJoin(&.{ global_cache_root, std.fs.path.basename(c_file) })});
 
             var arguments = std.ArrayList([]const u8).init(allocator);
             // pretend this is clang compiling
-            arguments.append("clang") catch @panic("OOM");
-            arguments.append(file_str) catch @panic("OOM");
-            arguments.appendSlice(&.{ "-o", output_str }) catch @panic("OOM");
+            arguments.appendSlice(&.{ "clang", c_file, "-o", output_str }) catch @panic("OOM");
             arguments.appendSlice(flags) catch @panic("OOM");
 
             // add host native include dirs and libs
@@ -235,7 +259,7 @@ fn makeCdb(step: *std.Build.Step, prog_node: std.Progress.Node) anyerror!void {
             const entry = CompileCommandEntry{
                 .arguments = arguments.toOwnedSlice() catch @panic("OOM"),
                 .output = output_str,
-                .file = file_str,
+                .file = c_file,
                 .directory = cwd_string,
             };
             compile_commands.append(entry) catch @panic("OOM");

--- a/flake.lock
+++ b/flake.lock
@@ -1,23 +1,58 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1693663421,
-        "narHash": "sha256-ImMIlWE/idjcZAfxKK8sQA7A1Gi/O58u5/CJA+mxvl8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e56990880811a451abd32515698c712788be5720",
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
-        "id": "nixpkgs",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1724224976,
+        "narHash": "sha256-Z/ELQhrSd7bMzTO8r7NZgi9g5emh+aRKoCdaAv5fiO0=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c374d94f1536013ca8e92341b540eba4c22f9c62",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "ref": "nixos-unstable",
-        "type": "indirect"
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,20 +1,32 @@
 {
-  description = "compile_commands generation for the zig build system. flake only supports x86_64-linux.";
+  description = "compile_commands generation for the zig build system";
 
-  inputs.nixpkgs.url = "nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs?ref=nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
 
-  outputs = { nixpkgs, ... }:
-    let
-      system = "x86_64-linux";
-      pkgs = import nixpkgs { inherit system; };
-    in
-    {
-      devShell.${system} =
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }: let
+    supportedSystems = let
+      inherit (flake-utils.lib) system;
+    in [
+      system.aarch64-linux
+      system.x86_64-linux
+    ];
+  in
+    flake-utils.lib.eachSystem supportedSystems (system: let
+      pkgs = import nixpkgs {inherit system;};
+    in {
+      devShell =
         pkgs.mkShell
-          {
-            packages = with pkgs; [
-              zig_0_11
-            ];
-          };
-    };
+        {
+          packages = with pkgs; [
+            zig_0_13
+          ];
+        };
+    });
 }


### PR DESCRIPTION
```zig
        .compile_commands = .{
            .url = "https://github.com/the-argus/zig-compile-commands/archive/95c8fa158e350d505b55a87a59cc4836e9606032.tar.gz",
            .hash = "1220b92b277b33762a10b4f239edddfbe9aadd53af88c678f94443b0d2312d9526fa",
        },
```

This will make source paths properly cannonicalized, accounting for the builder that created them. This fixes #6 , mostly.  Paths to objects are now `/path/to/global_cache_root/source_file_basename.o`. Before it was just the source location with the `.c` or `.cpp` swapped with `.o`. It still does not accurately represent the location of the object file compiled by zig, which I believe ends up in a generated directory with a random hash name.

I've tested this on NixOS linux with mainline 0.13.0.