### PR TITLE
Return step so that callers can add custom step dependencies

### DIFF
--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -18,7 +18,7 @@ const CompileCommandEntry = struct {
     output: []const u8,
 };
 
-pub fn createStep(b: *std.Build, name: []const u8, targets: []*std.Build.Step.Compile) void {
+pub fn createStep(b: *std.Build, name: []const u8, targets: []*std.Build.Step.Compile) *std.Build.Step {
     const step = b.allocator.create(std.Build.Step) catch @panic("Allocation failure, probably OOM");
 
     compile_steps = targets;
@@ -32,6 +32,8 @@ pub fn createStep(b: *std.Build, name: []const u8, targets: []*std.Build.Step.Co
 
     const cdb_step = b.step(name, "Create compile_commands.json");
     cdb_step.dependOn(step);
+
+    return step;
 }
 
 fn extractIncludeDirsFromCompileStepInner(b: *std.Build, step: *std.Build.Step.Compile, lazy_path_output: *std.ArrayList(std.Build.LazyPath)) void {


### PR DESCRIPTION
I was having issues where Zig was not evaluating a dependency before the compile commands step was evaluated, causing a panic.

So, expanding on the example in the README:
```zig
var targets = std.ArrayList(*std.Build.Step.Compile).init(b.allocator);
targets.append(my_exe) catch @panic("OOM");
const zcc_step = zcc.createStep(b, "gen-cc", targets.toOwnedSlice() catch @panic("OOM"));
zcc_step.dependOn(&my_exe.step);
```

The change in this PR allowed me to do what is shown in the example above, and resolved the issue for my use case.