### PR TITLE
Create flags from macro definitions

### DIFF
--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -176,6 +176,11 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*Absolut
             shared_flags.append(allocator, includeFlag(allocator, include_dir)) catch @panic("OOM");
         }
 
+        // create flags out of all macro definitions
+        for (step.root_module.c_macros.items) |macro| {
+            shared_flags.append(allocator, macro) catch @panic("OOM");
+        }
+
         for (step.root_module.link_objects.items) |link_object| {
             switch (link_object) {
                 .static_path => {


### PR DESCRIPTION
clang can infer what macros are available and their values by utilizing definition from ```-D=FOO="foo"```, zig provides:
```zig
pub fn addCMacro(m: *Module, name: []const u8, value: []const u8) void {
    const b = m.owner;
    m.c_macros.append(b.allocator, b.fmt("-D{s}={s}", .{ name, value })) catch @panic("OOM");
}
```
that help create these macros, but the default behavior of this zcc module does detect them so I added a way to get the macros and add them to the flags by using the `module.c_macros` that holds the macro definitions.