### PR TITLE
Check if generated files have a valid path

### DIFF
--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -109,7 +109,18 @@ pub fn extractIncludeDirsFromCompileStep(b: *std.Build, step: *std.Build.Step.Co
 
     // resolve lazy paths all at once
     for (dirs.items) |lazy_path| {
-        dirs_as_strings.append(b.allocator, lazy_path.getPath(b)) catch @panic("OOM");
+        const valid_path = switch (lazy_path) {
+            .generated => |gen| gen.file.path != null,
+            else => true,
+        };
+
+        if (valid_path) {
+            const p = lazy_path.getPath3(b, &step.step);
+            dirs_as_strings.append(b.allocator, b.pathResolve(&.{
+                p.root_dir.path orelse ".",
+                p.sub_path,
+            })) catch @panic("OOM");
+        }
     }
 
     return dirs_as_strings.toOwnedSlice(b.allocator) catch @panic("OOM");


### PR DESCRIPTION
This PR resolves a panic when a generated header directory does not contain a valid path. Also changes the getPath() call to getPath3(), as getPath() is marked deprecated. 

## Reproducing the issue
I ran into this issue when generating compile commands with [tiawl's dear imgui package](https://github.com/tiawl/cimgui.zig). I'm not sure if this can be fixed on their end, but i think this PR adds robustness anyway.  Minimal reproducible example:
```sh
zig init --minimal
zig fetch --save git+https://github.com/tiawl/cimgui.zig
zig fetch --save=compile_commands git+https://github.com/the-argus/zig-compile-commands/
```
`build.zig`:
```zig
const std = @import("std");

const cimgui = @import("cimgui_zig");
const zcc = @import("compile_commands");

pub fn build(b: *std.Build) void {
    const target = b.standardTargetOptions(.{});
    const optimize = b.standardOptimizeOption(.{});

    const exe = b.addExecutable(.{
        .name = "example",
        .root_module = b.createModule(.{
            .target = target,
            .optimize = optimize,
        }),
    });
    const cimgui_dep = b.dependency("cimgui_zig", .{
        .target = target,
        .optimize = optimize,
        .platforms = &[_]cimgui.Platform{.SDLGPU3},
        .renderers = &[_]cimgui.Renderer{.Vulkan},
    });
    exe.root_module.linkLibrary(cimgui_dep.artifact("cimgui"));

    var targets = std.ArrayListUnmanaged(*std.Build.Step.Compile){};
    targets.append(b.allocator, exe) catch @panic("OOM");
    _ = zcc.createStep(b, "cdb", targets.toOwnedSlice(b.allocator) catch @panic("OOM"));
}
```

