### PR TITLE
Update to Zig 0.16.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zig_compile_commands,
     .fingerprint = 0xa55d894ff9399839,
     .version = "0.0.1",
-    .minimum_zig_version = "0.15.1",
+    .minimum_zig_version = "0.16.0",
     .paths = .{
         "build.zig",
         "compile_commands.zig",

--- a/compile_commands.zig
+++ b/compile_commands.zig
@@ -71,7 +71,7 @@ fn extractIncludeDirsFromCompileStepInner(b: *std.Build, step: *std.Build.Step.C
             .other_step => |other_step| {
                 lazy_path_output.append(b.allocator, other_step.getEmittedIncludeTree()) catch @panic("OOM");
                 // recurse- this step may have included child dependencies
-                var local_lazy_path_output = std.ArrayList(std.Build.LazyPath){};
+                var local_lazy_path_output: std.ArrayList(std.Build.LazyPath) = .empty;
                 defer local_lazy_path_output.deinit(b.allocator);
                 extractIncludeDirsFromCompileStepInner(b, other_step, &local_lazy_path_output);
                 lazy_path_output.appendSlice(b.allocator, local_lazy_path_output.items) catch @panic("OOM");
@@ -105,13 +105,13 @@ fn extractIncludeDirsFromCompileStepInner(b: *std.Build, step: *std.Build.Step.C
 /// well as other compile steps. This loops until all the include directories
 /// necessary for good intellisense on the files compile by this step are found.
 pub fn extractIncludeDirsFromCompileStep(b: *std.Build, step: *std.Build.Step.Compile) []const []const u8 {
-    var dirs = std.ArrayList(std.Build.LazyPath){};
+    var dirs: std.ArrayList(std.Build.LazyPath) = .empty;
     defer dirs.deinit(b.allocator);
 
     // populates dirs
     extractIncludeDirsFromCompileStepInner(b, step, &dirs);
 
-    var dirs_as_strings = std.ArrayList([]const u8){};
+    var dirs_as_strings: std.ArrayList([]const u8) = .empty;
     defer dirs_as_strings.deinit(b.allocator);
 
     // resolve lazy paths all at once
@@ -137,7 +137,7 @@ pub fn extractIncludeDirsFromCompileStep(b: *std.Build, step: *std.Build.Step.Co
 /// Otherwise, it makes the relative path to the source file absolute by
 /// appending it to the builder passed in to this function.
 fn makeCSourcePathsAbsolute(b: *std.Build, c_sources: CSourceFiles) AbsoluteCSourceFiles {
-    var cpaths = std.ArrayList([]const u8){};
+    var cpaths: std.ArrayList([]const u8) = .empty;
     defer cpaths.deinit(b.allocator);
 
     for (c_sources.files) |file| {
@@ -158,11 +158,11 @@ fn makeCSourcePathsAbsolute(b: *std.Build, c_sources: CSourceFiles) AbsoluteCSou
 // array are allocated with the allocator, some are not.
 fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*AbsoluteCSourceFiles {
     var allocator = b.allocator;
-    var res = std.ArrayList(*AbsoluteCSourceFiles){};
+    var res: std.ArrayList(*AbsoluteCSourceFiles) = .empty;
 
     // move the compile steps into a mutable dynamic array, so we can add
     // any child steps
-    var compile_steps_list = std.ArrayList(*std.Build.Step.Compile){};
+    var compile_steps_list: std.ArrayList(*std.Build.Step.Compile) = .empty;
     compile_steps_list.appendSlice(allocator, steps) catch @panic("OOM");
 
     var index: u32 = 0;
@@ -171,7 +171,7 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*Absolut
     while (index < compile_steps_list.items.len) {
         const step = compile_steps_list.items[index];
 
-        var shared_flags = std.ArrayList([]const u8){};
+        var shared_flags: std.ArrayList([]const u8) = .empty;
         defer shared_flags.deinit(allocator);
 
         // Add a --target flag when compiling for other architectures
@@ -231,7 +231,7 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*Absolut
 
                     const abs_source_file = allocator.create(AbsoluteCSourceFiles) catch @panic("Allocation failure, probably OOM");
 
-                    var flags = std.ArrayList([]const u8){};
+                    var flags: std.ArrayList([]const u8) = .empty;
                     flags.appendSlice(allocator, link_object.c_source_file.flags) catch @panic("OOM");
                     flags.appendSlice(allocator, shared_flags.items) catch @panic("OOM");
 
@@ -249,7 +249,7 @@ fn getCSources(b: *std.Build, steps: []const *std.Build.Step.Compile) []*Absolut
                 },
                 .c_source_files => {
                     var source_files = link_object.c_source_files;
-                    var flags = std.ArrayList([]const u8){};
+                    var flags: std.ArrayList([]const u8) = .empty;
                     flags.appendSlice(allocator, source_files.flags) catch @panic("OOM");
                     flags.appendSlice(allocator, shared_flags.items) catch @panic("OOM");
                     source_files.flags = flags.toOwnedSlice(allocator) catch @panic("OOM");
@@ -274,19 +274,20 @@ fn makeCdb(step: *std.Build.Step, make_options: std.Build.Step.MakeOptions) anye
     _ = make_options;
     const allocator = step.owner.allocator;
     const b = step.owner;
+    const io = step.owner.graph.io;
     // NOTE: these are not sane defaults really, but atm I don't care about accurately providing the
     // location of the built .o object file to clangd
-    const global_cache_root = b.graph.global_cache_root.path orelse b.cache_root.path orelse (try std.fs.cwd().realpathAlloc(allocator, "."));
+    const global_cache_root = b.graph.global_cache_root.path orelse b.cache_root.path orelse (try std.Io.Dir.cwd().realPathFileAlloc(io, ".", allocator));
 
-    var compile_commands = std.ArrayList(CompileCommandEntry){};
+    var compile_commands: std.ArrayList(CompileCommandEntry) = .empty;
     defer compile_commands.deinit(allocator);
 
     // initialize file and struct containing its future contents
-    const cwd: std.fs.Dir = std.fs.cwd();
-    var file = try cwd.createFile("compile_commands.json", .{});
-    defer file.close();
+    const cwd: std.Io.Dir = std.Io.Dir.cwd();
+    var file = try cwd.createFile(io, "compile_commands.json", .{});
+    defer file.close(io);
 
-    const cwd_string = try dirToString(cwd, allocator);
+    const cwd_string = try dirToString(io, cwd, allocator);
     const c_sources = getCSources(step.owner, compile_steps.?);
 
     // fill compile command entries, one for each file
@@ -296,7 +297,7 @@ fn makeCdb(step: *std.Build.Step, make_options: std.Build.Step.MakeOptions) anye
             // NOTE: this is not accurate- not actually generating the hashed subdirectory names
             const output_str = b.fmt("{s}.o", .{b.pathJoin(&.{ global_cache_root, std.fs.path.basename(c_file) })});
 
-            var arguments = std.ArrayList([]const u8){};
+            var arguments: std.ArrayList([]const u8) = .empty;
             // pretend this is clang compiling
             arguments.appendSlice(allocator, &.{ cc_options.driver orelse "clang", c_file, "-o", output_str }) catch @panic("OOM");
             arguments.appendSlice(allocator, flags) catch @panic("OOM");
@@ -322,12 +323,12 @@ fn makeCdb(step: *std.Build.Step, make_options: std.Build.Step.MakeOptions) anye
         }
     }
 
-    try writeCompileCommands(&file, compile_commands.items);
+    try writeCompileCommands(io, &file, compile_commands.items);
 }
 
-fn writeCompileCommands(file: *std.fs.File, compile_commands: []CompileCommandEntry) !void {
+fn writeCompileCommands(io: std.Io, file: *std.Io.File, compile_commands: []CompileCommandEntry) !void {
     var buf: [std.json.default_buffer_size]u8 = undefined;
-    var writer = file.*.writer(&buf);
+    var writer = file.*.writer(io, &buf);
     var stringify = std.json.Stringify{
         .writer = &writer.interface,
         .options = .{
@@ -340,10 +341,10 @@ fn writeCompileCommands(file: *std.fs.File, compile_commands: []CompileCommandEn
     try writer.interface.flush();
 }
 
-fn dirToString(dir: std.fs.Dir, allocator: std.mem.Allocator) ![]const u8 {
-    var real_dir = try dir.openDir(".", .{});
-    defer real_dir.close();
-    return std.fs.realpathAlloc(allocator, ".") catch |err| {
+fn dirToString(io: std.Io, dir: std.Io.Dir, allocator: std.mem.Allocator) ![]const u8 {
+    var real_dir = try dir.openDir(io, ".", .{});
+    defer real_dir.close(io);
+    return real_dir.realPathFileAlloc(io, ".", allocator) catch |err| {
         std.debug.print("error encountered in converting directory to string.\n", .{});
         return err;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -25,7 +25,7 @@
         pkgs.mkShell
         {
           packages = with pkgs; [
-            zig_0_15
+            zig_0_16
           ];
         };
     });


### PR DESCRIPTION
Thank you for maintaining this repo! :-)

Quick little PR to have it working on 0.16.0:
- Updated `build.zig.zon` minimum Zig version to 0.16.0
- `ArrayList` objects now use `.empty` to initialize instead of using struct literal
- `makeCdb` now provides Io object
- `writeCompileCommands` & `dirToString` now accept Io interface as param
- Io interface passed where required to std library functions
- Updated `flake.nix` to use `zig_0_16`

Changed:
- `std.fs.Dir` -> `std.Io.Dir`
- `std.fs.cwd `-> `std.Io.Dir.cwd`
- `std.fs.File` -> `std.Io.File`
- `std.fs.realpathAlloc` -> `std.Io.Dir.realPathFileAlloc`